### PR TITLE
Added Commerce support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 - 2020-03-09
+### Added
+- Support for Craft Commerce. Title is now put in the sidebar when editing a product
+
 ## 1.0.1 - 2019-06-27
 ### Fixed
 - Fixed a bug where title's weren't being escaped

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "thejoshsmith/craft-title-to-sidebar",
     "description": "Moves the title field to the sidebar",
     "type": "craft-plugin",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/web/assets/dist/js/titleToSidebar.js
+++ b/src/web/assets/dist/js/titleToSidebar.js
@@ -5,13 +5,20 @@
  * @copyright Copyright (c) 2019 Josh Smith
  * @link      https://www.joshsmith.dev
  * @package   Title to Sidebar
- * @since     1.0.0
+ * @since     1.1.0
  */
 ;(function($){
 
     if( window.titleToSidebar == null || window.titleToSidebar.hasTitleField == null || window.titleToSidebar.hasTitleField === false ) return;
 
-    $('#settings').prepend(
+    var target = '#settings';
+
+    if( window.titleToSidebar.entryType == 'product' ){
+        $('#title-field').remove();
+        var target = '#details .meta:first-of-type';
+    }
+
+    $(target).prepend(
         '<div class="field" id="title-sidebar">' +
             '<div class="heading">' +
                 '<label id="title-label" for="title">'+(window.titleToSidebar.titleLabel || '')+'</label>' +


### PR DESCRIPTION
**Whats changed**
- added support for commerce products
- bumped version to 1.1.0 (changelog, composer)

**Notes**
The title field doesn't work the same as it does on entries e.g. it's not wrapped in the check "hasTitleField" so a simple piece of javascript is added to remove the defaut title while the new one is added to the sidebar.